### PR TITLE
Telemetry data using self-hosted Plausible analytics

### DIFF
--- a/.github/workflows/deploy.prod.yml
+++ b/.github/workflows/deploy.prod.yml
@@ -32,6 +32,9 @@ jobs:
 
       - name: Build
         run: yarn build
+        env:
+          VUE_APP_DOMAIN: tempo.agate.blue
+          VUE_APP_PLAUSIBLE_HOST: https://stats.agate.blue
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@v4.2.5

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "roboto-fontface": "*",
     "truncate-html": "^1.0.4",
     "vue": "^2.6.14",
+    "vue-plausible": "^1.3.1",
     "vue-router": "^3.5.3",
     "vuedraggable": "^2.24.3",
     "vuetify": "^2.6.3",

--- a/src/App.vue
+++ b/src/App.vue
@@ -103,7 +103,7 @@ export default {
   },
   mounted() {
     let self = this;
-    // we have some internal links in rendered markdown but cannot use rotueur link there, so when a
+    // we have some internal links in rendered markdown but cannot use router link there, so when a
     // click is made on a link ith the appropriate class, we push via the router
     window.onclick = function(e) {
       var className = "internal-link"; // any css selector for children

--- a/src/main.js
+++ b/src/main.js
@@ -4,8 +4,10 @@ import './registerServiceWorker'
 import router from './router'
 import store from './store'
 import vuetify from './plugins/vuetify';
+import { VuePlausible } from 'vue-plausible'
 
 Vue.config.productionTip = false
+
 
 // three shaking icons to reduce bundle size
 import {
@@ -95,6 +97,18 @@ Vue.prototype.$theme = {
   mainButton: {
     color: "pink darken-4",
   },
+}
+if (process.env.VUE_APP_PLAUSIBLE_HOST) {
+  let options = {
+    apiHost: process.env.VUE_APP_PLAUSIBLE_HOST,
+    hashMode: true,
+    enableAutoPageviews: false,
+    trackLocalhost: process.env.VUE_APP_PLAUSIBLE_TRACK_LOCALHOST == "true" ? true : false,
+  }
+  if (process.env.VUE_APP_DOMAIN) {
+    options.domain = process.env.VUE_APP_DOMAIN
+  }
+  Vue.use(VuePlausible, options)
 }
 new Vue({
   router,

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,4 @@
+import Vue from 'vue'
 import sortBy from 'lodash/sortBy'
 
 const signToMood = {
@@ -417,6 +418,7 @@ export function makeFile (window, text, mimetype) {
 }
 
 export const SETTINGS = [
+  {name: "telemetry", default: () => {return true}},
   {name: "webhook", default: () => {return {}}},
   {name: "charts", default: () => {return []}},
   {name: "aliases", default: () => {return []}},
@@ -455,4 +457,30 @@ export async function bulkInsertAndUpdate(arr, db) {
 
 export function getShortEntryId (id) {
   return id.toISOString()
+}
+
+
+export function getCleanUrlForTracking (location, path) {
+  // remove querystring since it may contain sensitive data
+  path = path.split('?')[0]
+  return `${location.protocol}//${location.hostname}${path}`
+}
+
+export function trackEvent(store, event, props = {}, eventData = {}) {
+  console.debug("[event] tracking", event, props)
+  if (!store.getters["settings"].telemetry) {
+    console.debug("[event] skipping, telemetry disabled")
+    return
+  }
+  try {
+    Vue.$plausible.trackEvent(event, {props, callback () {
+      console.debug("[event] sent")
+    }}, {
+      url: getCleanUrlForTracking(window.location, window.location.href.split("#")[1]),
+      referrer: null,
+      ...eventData,
+    })
+  } catch (e) {
+    console.warn("Could not track event", e)
+  }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -467,7 +467,7 @@ export function getCleanUrlForTracking (location, path) {
 }
 
 export function trackEvent(store, event, props = {}, eventData = {}) {
-  console.debug("[event] tracking", event, props)
+  console.debug("[event] tracking", event)
   if (!store.getters["settings"].telemetry) {
     console.debug("[event] skipping, telemetry disabled")
     return

--- a/src/utils.js
+++ b/src/utils.js
@@ -468,8 +468,13 @@ export function getCleanUrlForTracking (location, path) {
 
 export function trackEvent(store, event, props = {}, eventData = {}) {
   console.debug("[event] tracking", event)
+
+  if (!process.env.VUE_APP_PLAUSIBLE_HOST) {
+    console.debug("[event] skipping, telemetry disabled at build time")
+    return
+  }
   if (!store.getters["settings"].telemetry) {
-    console.debug("[event] skipping, telemetry disabled")
+    console.debug("[event] skipping, telemetry disabled by user")
     return
   }
   try {

--- a/src/utils.js
+++ b/src/utils.js
@@ -467,19 +467,19 @@ export function getCleanUrlForTracking (location, path) {
 }
 
 export function trackEvent(store, event, props = {}, eventData = {}) {
-  console.debug("[event] tracking", event)
+  console.debug("[telemetry] tracking", event)
 
   if (!process.env.VUE_APP_PLAUSIBLE_HOST) {
-    console.debug("[event] skipping, telemetry disabled at build time")
+    console.debug("[telemetry] skipping, disabled at build time")
     return
   }
   if (!store.getters["settings"].telemetry) {
-    console.debug("[event] skipping, telemetry disabled by user")
+    console.debug("[telemetry] skipping, disabled by user")
     return
   }
   try {
     Vue.$plausible.trackEvent(event, {props, callback () {
-      console.debug("[event] sent")
+      console.debug("[telemetry] sent")
     }}, {
       url: getCleanUrlForTracking(window.location, window.location.href.split("#")[1]),
       referrer: null,

--- a/src/views/Diary.vue
+++ b/src/views/Diary.vue
@@ -27,7 +27,7 @@
 </template>
 
 <script>
-import {search} from '@/utils'
+import {search, trackEvent} from '@/utils'
 
 export default {
   props: {
@@ -45,11 +45,13 @@ export default {
     
     async handleCreated (entry) {
       this.entries.push(entry)
+      trackEvent(this.$store, "entry.created")
     },
     async handleDelete (entry) {
       this.entries = this.entries.filter((e) => {
         return e._id != entry._id
       })
+      trackEvent(this.$store, "entry.deleted")
     },
     async handleUpdate (entry) {
       this.entries.forEach((e) => {
@@ -57,6 +59,7 @@ export default {
           Object.assign(e, entry)
         }
       })
+      trackEvent(this.$store, "entry.updated")
     },
     async search () {
       this.entries = await search({

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -167,6 +167,28 @@
       </v-card-text>
     </v-card>
 
+    <v-card tag="section" id="telemetry" class="mb-8" :color="$theme.card.color">
+      <v-card-title class="headline">Telemetry</v-card-title>
+
+      <v-card-text :class="$theme.card.textSize">
+        <p>
+          Tempo collects some anonymous telemetry data.
+          This data is very valuable for us as it helps us understand how people are using the application.
+        </p>
+        <p>
+          We do not collect any personal information such as IP adresses, cookies, mood, notes, tasks or search queries.
+          Telemetry data is hosted by Agate, in France, and not shared with any third party. 
+        </p>
+        <p>You can opt-out from data collection using the switch below.</p>
+
+        <v-switch
+          v-model="telemetryEnabled"
+          label="Send telemetry data"
+          @change="updateTelemetry($event)"
+        ></v-switch>
+      </v-card-text>
+    </v-card>
+
     <v-card tag="section" id="delete" class="mb-8" :color="$theme.card.color">
       <v-card-title class="headline">Delete your data</v-card-title>
 
@@ -279,7 +301,8 @@ export default {
       webhook: this.$store.state.settings.webhook || {
         url: '',
       },
-      trackEvent
+      telemetryEnabled: this.$store.getters['settings'].telemetry,
+      trackEvent,
     }
   },
   methods: {
@@ -365,6 +388,12 @@ export default {
       } catch (e) {
         this.syncStatus = `Error: ${e.name || e}`
       }
+    },
+    async updateTelemetry (v) {
+      if (!v) {
+        trackEvent(this.$store, "telemetry.disabled")
+      }
+      await this.$store.dispatch("setSetting", {name: "telemetry", value: v})
     }
   }
 }

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -26,7 +26,7 @@
           />
           <alias-form
             :key="String(lastAliasesUpdate)"
-            @created="lastAliasesUpdate = new Date()" />
+            @created="lastAliasesUpdate = new Date(); trackEvent($store, 'alias.created')" />
         </v-form>
       </v-card-text>
     </v-card>
@@ -161,7 +161,7 @@
         <v-btn
           color="primary"
           :disabled="!webhook.url"
-          @click="$store.dispatch('setWebhook', {url: webhook.url})">
+          @click="$store.dispatch('setWebhook', {url: webhook.url}); trackEvent($store, 'webhook.setup')">
           Save
         </v-btn>
       </v-card-text>
@@ -185,7 +185,7 @@
 <script>
 import AliasForm from '@/components/AliasForm'
 
-import {search, getTasks, downloadFile, getSettings, bulkInsertAndUpdate} from '@/utils'
+import {search, getTasks, downloadFile, getSettings, bulkInsertAndUpdate, trackEvent} from '@/utils'
 
 async function importEntries(entries, db, logs) {
   entries = entries || []
@@ -278,7 +278,8 @@ export default {
       couchDbPassword: this.$store.state.couchDbPassword,
       webhook: this.$store.state.settings.webhook || {
         url: '',
-      }
+      },
+      trackEvent
     }
   },
   methods: {
@@ -312,6 +313,7 @@ export default {
         'application/json',
         `tempo_export_${d}.json`
       )
+      trackEvent(this.$store, "data.exported")
     },
     async triggerWebhook (url) {
       await this.$store.dispatch("forceSync")
@@ -338,12 +340,14 @@ export default {
         await this.$store.dispatch("loadSettings")
       }
       this.importLogs.push(`[info] Import complete!`)
+      trackEvent(this.$store, "data.imported")
     },
     deleteConfirm () {
       if (confirm("This will remove all your notes. This action is irreversible.")) {
         this.$store.dispatch('reset')
         this.importedEntries = 0
         this.failedEntries = 0
+        trackEvent(this.$store, "data.deleted")
       }
     },
     async setupSync () {
@@ -357,6 +361,7 @@ export default {
           }
         )
         this.syncStatus = `Sync OK!`
+        trackEvent(this.$store, "sync.setup")
       } catch (e) {
         this.syncStatus = `Error: ${e.name || e}`
       }

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -177,10 +177,9 @@
         </p>
         <p>
           We do not collect any personal information such as IP adresses, cookies, mood, notes, tasks or search queries.
-          Telemetry data is hosted by Agate, in France, and not shared with any third party.
-          If you are interested, you can
+          Telemetry data is hosted by Agate, in France, and 
           <a href="https://stats.agate.blue/tempo.agate.blue" _blank="true">
-            access this telemetry data yourself.
+            available publicly for transparency.
           </a>
         </p>
         <p>You can opt-out from data collection using the switch below.</p>

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -177,7 +177,11 @@
         </p>
         <p>
           We do not collect any personal information such as IP adresses, cookies, mood, notes, tasks or search queries.
-          Telemetry data is hosted by Agate, in France, and not shared with any third party. 
+          Telemetry data is hosted by Agate, in France, and not shared with any third party.
+          If you are interested, you can
+          <a href="https://stats.agate.blue/tempo.agate.blue" _blank="true">
+            access this telemetry data yourself.
+          </a>
         </p>
         <p>You can opt-out from data collection using the switch below.</p>
 

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -167,7 +167,7 @@
       </v-card-text>
     </v-card>
 
-    <v-card tag="section" id="telemetry" class="mb-8" :color="$theme.card.color">
+    <v-card v-if="telemetryServer" tag="section" id="telemetry" class="mb-8" :color="$theme.card.color">
       <v-card-title class="headline">Telemetry</v-card-title>
 
       <v-card-text :class="$theme.card.textSize">
@@ -302,6 +302,7 @@ export default {
         url: '',
       },
       telemetryEnabled: this.$store.getters['settings'].telemetry,
+      telemetryServer: process.env.VUE_APP_PLAUSIBLE_HOST,
       trackEvent,
     }
   },

--- a/src/views/Tasks.vue
+++ b/src/views/Tasks.vue
@@ -8,7 +8,7 @@
       <v-card-title class="headline">Update your board</v-card-title>
 
       <v-card-text :class="$theme.card.textSize">
-        <board-form @updated="tasksByList = getTasksByList(); isEditing = false"></board-form>
+        <board-form @updated="tasksByList = getTasksByList(); isEditing = false; trackEvent($store, 'board.updated')"></board-form>
       </v-card-text>
     </v-card>
     <template v-else>
@@ -106,9 +106,9 @@
                   
                   :is-done="idx === $store.getters['boardLists'].length - 1"
                   
-                  @done="moveCard($event._id, $store.getters['boardLists'].length - 1)"
-                  @deleted="updateTasks"
-                  @updated="updateTasks"
+                  @done="moveCard($event._id, $store.getters['boardLists'].length - 1); trackEvent($store, 'task.completed')"
+                  @deleted="updateTasks; trackEvent($store, 'task.deleted')"
+                  @updated="updateTasks; trackEvent($store, 'task.updated')"
                   ></task-card>
               </v-lazy>
             </draggable>
@@ -122,7 +122,7 @@
 <script>
 
 import sortBy from 'lodash/sortBy'
-import {getTasks} from '@/utils'
+import {getTasks, trackEvent} from '@/utils'
 
 export default {
   props: {
@@ -152,6 +152,7 @@ export default {
       tasksByList: {},
       newTaskText: '',
       newTaskCategory: null,
+      trackEvent,
     }
   },
   async created () {
@@ -190,6 +191,7 @@ export default {
       this.tasks.push(task)
       this.newTaskText = null
       this.newTaskCategory = null
+      trackEvent(this.$store, "task.created")
     },
     async updateTasks () {
       this.tasks = await getTasks(this.$store, this.query)

--- a/yarn.lock
+++ b/yarn.lock
@@ -7432,6 +7432,11 @@ pkg-up@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
+plausible-tracker@^0.3.4:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/plausible-tracker/-/plausible-tracker-0.3.5.tgz#49c09a7eb727f1d5c859c3fc8072837b13ee9b85"
+  integrity sha512-6c6VPdPtI9KmIsfr8zLBViIDMt369eeaNA1J8JrAmAtrpSkeJWvjwcJ+cLn7gVJn5AtQWC8NgSEee2d/5RNytA==
+
 pn@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
@@ -10176,6 +10181,13 @@ vue-loader@^15.8.3:
     loader-utils "^1.1.0"
     vue-hot-reload-api "^2.3.0"
     vue-style-loader "^4.1.0"
+
+vue-plausible@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/vue-plausible/-/vue-plausible-1.3.1.tgz#c8d5906566433c7f5a0a27878745f355eccf9172"
+  integrity sha512-OqZiScz/7glitE4XSJTwGUHO31VEbba2efmLki0+rIGDx3NysSOBJMyFz6yBFPWKms4jb1lDmx1wCsbAl7mrtA==
+  dependencies:
+    plausible-tracker "^0.3.4"
 
 vue-router@^3.5.3:
   version "3.5.3"


### PR DESCRIPTION
This PR implements some basic telemetry collection to help me understand how the app is used.

Collection is fully GDPR compliant and anonymous, as explained on the settings page in Tempo:

```
Tempo collects some anonymous telemetry data. This data is very valuable for us as it helps us understand how people are using the application.

We do not collect any personal information such as IP adresses, cookies, mood, notes, tasks or search queries. Telemetry data is hosted by Agate, in France, and available publicly for transparency.

You can opt-out from data collection using the switch below.
```

Since we don't use cookies, and don't collect any personal information, this is enabled by default. Users can opt out at any time from the Settings page.

For full transparency, telemetry data is available to everyone : https://stats.agate.blue/tempo.agate.blue

# Screenshof of the updated settings page

![Screenshot_20220402_095557](https://user-images.githubusercontent.com/1970915/161373063-f75d92c8-dd3f-4637-befe-ee24c8ffd6f0.png)
