### PR TITLE
Threads implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ In addition, the diary support advanced use cases and features. All these featur
 
 You can use titles, bullet list, links, emphasis and other Markdown syntax inside your entries, and have them rendered properly once the note is saved. If you are not familiar with Markdown syntax, you can [learn how to use it in a couple minutes](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet).
 
+### Favorites
+
+Entries can be favorited to be quickly found when you most need them.
+
 ### Tags
 
 Prefixing any word with a `#` will render it as a hashtag, like this: `Played some #guitar tonight.`. As hashtags can easily be clicked and searched for, this helps you organize your diary without spending too much time thinking about it
@@ -43,6 +47,12 @@ Prefixing any word with a `#` will render it as a hashtag, like this: `Played so
 Similarly, prefixing a word with an exclamation mark, like this: `Got my first !tattoo today`, will tag entries as important and give you a way to quickly retrieve and browse them afterwards.
 
 Tempo supports several other type of tags, related to its mood tracking capabilities and thus described below. 
+
+### Threads
+
+Entries in the diary can have replies, which is especially useful if you want to group them. For instance, you can use a single thread to gather everything related to an event (planning, notes, feedback, etc.)
+
+Thread replies are regular diary entries and, as such, can be queried, favorited, contain tags, annotations, etc.
 
 ### Annotations
 
@@ -59,7 +69,6 @@ Got my blood test results:
 
 This data can then be used to build graphical vizualisations such as charts, tables, or even be exported for use in other tools. You can read more on annotations in the dedicated section below.
 
-
 ### Querying and search
 
 Tempo includes a search bar and a powerful query language you can use to quickly find entries:
@@ -73,6 +82,10 @@ Tempo includes a search bar and a powerful query language you can use to quickly
 - Tag type search:
     - `#` gives you entries with any hashtag
     - `!` gives you all important entries
+- Other operators:
+    - `is:favorite` gives you all favorited entries
+    - `is:thread` gives you all first entries of a thread
+    - `is:reply` gives you all replies thread
 
 All these operators can be combined to further refine your search:
 

--- a/src/components/EntryForm.vue
+++ b/src/components/EntryForm.vue
@@ -54,7 +54,7 @@
         </div>
         <div>
           <v-btn
-            v-if="entry" 
+            v-if="entry || thread" 
             text
             small
             @click="$emit('cancel')"
@@ -77,6 +77,7 @@ import {getNewEntryData} from '@/utils'
 export default {
   props: {
     entry: {type: Object, default: null},
+    thread: {type: String, default: null},
     name: {type: String, default: 'how'},
     initialText: {type: String, default: ''},
     textareaLabel: {type: String, default: 'Entry content'},
@@ -131,7 +132,7 @@ export default {
     async addNew () {
       let date = this.date ? new Date(this.date) : new Date()
       let data = {
-        ...getNewEntryData(this.text),
+        ...getNewEntryData(this.text, {thread: this.thread}),
         date: date.toISOString(),
       }
       data._id = data.date
@@ -144,12 +145,13 @@ export default {
     async update () {
       let date = new Date(this.date || this.entry.date)
       let data = {
-        ...getNewEntryData(this.text),
+        ...getNewEntryData(this.text, {thread: this.entry.thread, replies: this.entry.replies}),
         _rev: this.entry._rev,
         _id: this.entry._id,
         date: date.toISOString(),
       }
       let e = await this.$store.dispatch('updateEntry', data)
+      this.$store.dispatch('forceSync', {updateLastSync: false})
       this.$emit('updated', e)
       return e
     },

--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -10,6 +10,7 @@
       >
         <entry
           @updated="$emit('updated', $event)"
+          @replied="$emit('replied', $event)"
           @deleted="$emit('deleted', $event)"
           :row="row"></entry>
       </v-card>
@@ -100,7 +101,12 @@ export default {
       let entries = [...this.entries]
       if (this.entryId) {
         entries = entries.filter(entry => {
-          return getShortEntryId(entry._id) == this.entryId
+          if (getShortEntryId(entry._id) === this.entryId) {
+            return true
+          } else if (entry.thread && getShortEntryId(entry.thread) === this.entryId) {
+            return true
+          }
+          return false
         })
       }
       entries.forEach((e) => {

--- a/src/main.js
+++ b/src/main.js
@@ -39,6 +39,8 @@ import {
   mdiMenuDown,
   mdiPencil,
   mdiPlus,
+  mdiReply,
+  mdiReplyOutline,
   mdiSend,
   mdiSync,
 } from '@mdi/js'
@@ -72,6 +74,8 @@ Vue.prototype.$icons = {
   mdiMenuDown,
   mdiPencil,
   mdiPlus,
+  mdiReply,
+  mdiReplyOutline,
   mdiSend,
   mdiSync,
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -59,7 +59,7 @@ export function insertTagMarkup (text) {
   }
 }
 
-export function getNewEntryData(text) {
+export function getNewEntryData(text, additionalValues = {}) {
   let entryData = {
     text,
     tags: parseTags(text),
@@ -67,6 +67,8 @@ export function getNewEntryData(text) {
     type: 'entry',
     data: null,
     favorite: false,
+    thread: additionalValues.thread || null,
+    replies: additionalValues.replies || [],
   }
   let annotations = []
   entryData.tags.forEach(t => {
@@ -121,6 +123,10 @@ export function parseQuery(query) {
       tokens.push({date: stripped.split(':')[1]})
     } else if (stripped.startsWith('is:fav')) {
       tokens.push({favorite: true})
+    } else if (stripped.startsWith('is:thread')) {
+      tokens.push({thread: true})
+    } else if (stripped.startsWith('is:reply')) {
+      tokens.push({reply: true})
     } else if (stripped.startsWith('t:') || stripped.startsWith('tag:') ) {
       tokens.push({tagName: stripped.split(/:(.+)/)[1]})
     } else if (stripped.startsWith('c:') || stripped.startsWith('category:') ) {
@@ -162,6 +168,12 @@ export function matchTokens(entry, tokens, aliasesById = {}) {
       }
     }
     if (token.favorite && !entry.favorite) {
+      return false
+    }
+    if (token.thread && (entry.replies || []).length === 0) {
+      return false
+    }
+    if (token.reply && !entry.thread) {
       return false
     }
     if (token.tagName) {
@@ -218,6 +230,8 @@ export function getCompleteEntry (e) {
     tags: {},
     data: e.data || null,
     favorite: e.favorite || false,
+    thread: e.thread || null,
+    replies: e.replies || [],
   }
   e.tags.forEach((t) => {
     entry.tags[t.id] = {

--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -174,6 +174,21 @@
                   Find favorited entries
                 </td>
               </tr>
+              <tr>
+                <td>
+                  <code>is:thread</code>
+                </td>
+                <td>
+                  Find first entry of a thread
+                </td>
+              </tr><tr>
+                <td>
+                  <code>is:reply</code>
+                </td>
+                <td>
+                  Find replies to an entry
+                </td>
+              </tr>
             </tbody>
           </template>
         </v-simple-table>

--- a/src/views/Diary.vue
+++ b/src/views/Diary.vue
@@ -21,6 +21,7 @@
       :all-entries="entries"
       @deleted="handleDelete"
       @updated="handleUpdate"
+      @replied="handleCreated"
       @created="handleCreated"
     ></router-view>
   </div>
@@ -48,9 +49,22 @@ export default {
       trackEvent(this.$store, "entry.created")
     },
     async handleDelete (entry) {
+      // small optimisation to avoid string comparison
+      // when entry is already deleted
+      let alreadyDeleted = false
+      let id = entry._id
       this.entries = this.entries.filter((e) => {
-        return e._id != entry._id
+        if (alreadyDeleted || e._id != id) {
+          return true
+        }
+        alreadyDeleted = true
+        return false
       })
+      // redirect to diary view if we were
+      // on detail view
+      if (this.$route.name === 'Entry') {
+        this.$router.push('/')
+      }
       trackEvent(this.$store, "entry.deleted")
     },
     async handleUpdate (entry) {
@@ -76,6 +90,13 @@ export default {
     "$store.state.lastSync": {
       async handler () {
         await this.search()
+      }
+    },
+    "$route.params.entryId": {
+      async handler (v) {
+        if (v) {
+          await this.search()
+        }
       }
     },
   },

--- a/src/views/Timeline.vue
+++ b/src/views/Timeline.vue
@@ -13,7 +13,12 @@
     </template>
     <v-container v-if="!entryId" class="py-0 px-0 narrow d-flex justify-end">
       <v-switch
-        v-model="showFavorites"
+        class="mr-2"
+        v-model="filters.threads"
+        label="Show threads"
+      ></v-switch>
+      <v-switch
+        v-model="filters.favorites"
         label="Show favorites"
       ></v-switch>
     </v-container>
@@ -35,6 +40,7 @@
       :entry-id="entryId"
       :key="`timeline-${$store.state.lastSync}`"
       @updated="$emit('updated', $event)"
+      @replied="$emit('replied', $event)"
       @deleted="$emit('deleted', $event)"></timeline>
     <v-container
       v-if="!entryId && shownEntries.length < entries.length"
@@ -71,7 +77,10 @@ export default {
   },
   data () {
     return {
-      showFavorites: false,
+      filters: {
+        favorites: false,
+        threads: false,
+      },
       showEntryModal: false,
       showShowMoreButton: false,
       count: this.$store.state.pageSize,
@@ -108,9 +117,18 @@ export default {
         this.showShowMoreButton = true
       }, 1000)
     },
-    showFavorites (v) {
-      let query = v ? 'is:fav' : ''
-      this.$store.commit('searchQuery', query)
+    filters: {
+      handler (v) {
+        let query = []
+        if (v.favorites) {
+          query.push('is:fav')
+        }
+        if (v.threads) {
+          query.push('is:threads')
+        }
+        this.$store.commit('searchQuery', query.join(' '))
+      },
+      deep: true
     }
   },
 }


### PR DESCRIPTION
- [x] Can reply to any entry
- [x] Can click on the brand new « view thread » and « view replies » on entries to see them in the context of the thread
- [x] Added a « show thread » filter near the previously implemented « show favorites » filter 
- [x] is:thread and is:reply search operators
- [x] Adjusted deletion logic to support deleting whole thread at once
- [x] Minor UX improvements: faster UI refresh during updates/deletion
- [x] Documentation for the whole thing

https://user-images.githubusercontent.com/1970915/187074450-54143053-ff4e-45a9-88eb-1985bbea7c26.mp4

