### PR TITLE
 Blueprints - Forms

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -87,7 +87,7 @@ export default {
   },
   async created() {
     await this.$store.dispatch('loadSettings')
-    await this.$store.dispatch("loadBlueprints", this.$store.state.settings.blueprints)
+    await this.$store.dispatch("loadBlueprints")
     if (navigator.serviceWorker) {
       navigator.serviceWorker.addEventListener("controllerchange", () => {
         if (this.$store.state.serviceWorker.refreshing) return;

--- a/src/App.vue
+++ b/src/App.vue
@@ -87,6 +87,7 @@ export default {
   },
   async created() {
     await this.$store.dispatch('loadSettings')
+    await this.$store.dispatch("loadBlueprints", this.$store.state.settings.blueprints)
     if (navigator.serviceWorker) {
       navigator.serviceWorker.addEventListener("controllerchange", () => {
         if (this.$store.state.serviceWorker.refreshing) return;

--- a/src/blueprints/builtin:mood.json
+++ b/src/blueprints/builtin:mood.json
@@ -1,6 +1,7 @@
 {
   "id": "builtin:mood",
   "label": "Mood",
+  "title": "Mood-related charts and visualizations",
   "version": "1",
   "vizualisations": [
     {

--- a/src/blueprints/builtin:tags.json
+++ b/src/blueprints/builtin:tags.json
@@ -1,6 +1,7 @@
 {
   "id": "builtin:tags",
   "label": "Tags",
+  "title": "Tags-related charts and visualizations",
   "version": "1",
   "vizualisations": [
     {

--- a/src/blueprints/builtin:travel.json
+++ b/src/blueprints/builtin:travel.json
@@ -1,7 +1,7 @@
 {
   "id": "builtin:travel",
   "label": "Travel",
-  "help": "Information about your trips (distance, destination, means of transportation…)",
+  "title": "Forms and visualizations for your trips",
   "version": "1",
   "fields": [
     {

--- a/src/blueprints/builtin:travel.json
+++ b/src/blueprints/builtin:travel.json
@@ -1,8 +1,44 @@
 {
   "id": "builtin:travel",
   "label": "Travel",
-  "help": "Traveling information (distance, destination, means of transportation…)",
+  "help": "Information about your trips (distance, destination, means of transportation…)",
   "version": "1",
+  "fields": [
+    {
+      "id": "travel:distance",
+      "label": "Distance",
+      "unit": "Kilometers",
+      "type": "number",
+      "min": 0
+    },
+    {
+      "id": "travel:from",
+      "label": "Place of departure",
+      "type": "text"
+    },
+    {
+      "id": "travel:to",
+      "label": "Destination",
+      "type": "text"
+    },
+    {
+      "id": "travel:by",
+      "label": "Transport",
+      "type": "text"
+    }
+  ],
+  "forms": [
+    {
+      "id": "travel:trip",
+      "label": "Trip",
+      "fields": [
+        {"id": "travel:from"},
+        {"id": "travel:to"},
+        {"id": "travel:distance"},
+        {"id": "travel:by"}
+      ]
+    }
+  ],
   "vizualisations": [
     {
       "label": "Travel distance",
@@ -26,47 +62,6 @@
       "query": "SELECT data->`travel:from` as `From`, data->`travel:to` as `To`, sum(data->`travel:distance`) as Distance FROM ? GROUP BY data->`travel:from`, data->`travel:to` ORDER BY Distance DESC",
       "chartType": "table",
       "chartOptions": {}
-    }
-  ],
-  "inputs": [
-    {
-      "id": "travel",
-      "prefix": "travel",
-      "fields": [
-        {
-          "id": "distance",
-          "label": "Distance",
-          "unit": "Kilometers",
-          "type": "number",
-          "min": 0
-        },
-        {
-          "id": "from",
-          "label": "Place of departure",
-          "type": "text"
-        },
-        {
-          "id": "to",
-          "label": "Destination",
-          "type": "text"
-        },
-        {
-          "id": "by",
-          "label": "Transport",
-          "type": "text",
-          "choices": [
-            "bike",
-            "boat",
-            "bus",
-            "car",
-            "foot",
-            "subway",
-            "tramway",
-            "train",
-            "plane"
-          ]
-        }
-      ]
     }
   ]
 }

--- a/src/components/BlueprintForm.vue
+++ b/src/components/BlueprintForm.vue
@@ -1,0 +1,55 @@
+<template>
+  <div>
+    <p v-if="config.help">{{ config.help }}</p>
+    <v-row>
+      <v-col
+        v-for="field in fields"
+        :key="field.id"
+        cols="12"
+        sm="6"
+      >
+        <v-text-field
+          :label="field.label"
+          :type="field.type || 'text'"
+          v-model="values[field.id]"
+          :required="field.required === undefined ? true : field.required"
+          clearable
+        ></v-text-field>
+      </v-col>
+    </v-row>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    value: {default: () => {return {}}},
+    config: {},
+    availableFields: {},
+  },
+  data () {
+    let values = {...this.value}
+    return {
+      values
+    }
+  },
+  computed: {
+    fields () {
+      return this.config.fields.map(f => {
+        return {
+          ...this.availableFields[f.id],
+          ...f
+        }
+      })
+    }
+  },
+  watch: {
+    values: {
+      deep: true,
+      handler (v) {
+        this.$emit('input', v)
+      }
+    }
+  }
+}
+</script>

--- a/src/components/BlueprintForm.vue
+++ b/src/components/BlueprintForm.vue
@@ -1,6 +1,6 @@
 <template>
-  <div>
-    <p v-if="config.help">{{ config.help }}</p>
+  <div v-if="fields.length > 0">
+    <p v-if="formConfig.help">{{ formConfig.help }}</p>
     <v-row>
       <v-col
         v-for="field in fields"
@@ -8,10 +8,17 @@
         cols="12"
         sm="6"
       >
+        <v-checkbox
+          v-if="field.type === 'boolean'"
+          v-model="values[field.id]"
+          :label="field.label"
+
+        />
         <v-text-field
+          v-else
+          v-model="values[field.id]"
           :label="field.label"
           :type="field.type || 'text'"
-          v-model="values[field.id]"
           :required="field.required === undefined ? true : field.required"
           clearable
         ></v-text-field>
@@ -21,6 +28,16 @@
 </template>
 
 <script>
+function getValueType(value) {
+  switch (typeof value) {
+    case 'boolean':
+      return 'boolean'
+    case 'number':
+      return 'number'
+    default:
+      return 'text'
+  }
+}
 export default {
   props: {
     value: {default: () => {return {}}},
@@ -34,8 +51,30 @@ export default {
     }
   },
   computed: {
+    formConfig () {
+      if (this.config) {
+        return this.config
+      }
+      else {
+        // offer a basic form to edit existing annotations that 
+        // may not belong to a form
+        let config = {
+          fields: []
+        }
+        for (const key in this.values) {
+          if (Object.hasOwnProperty.call(this.values, key)) {
+            config.fields.push({
+              label: key,
+              id: key,
+              type: getValueType(this.values[key]),
+            })
+          }
+        }
+        return config
+      }
+    },
     fields () {
-      return this.config.fields.map(f => {
+      return this.formConfig.fields.map(f => {
         return {
           ...this.availableFields[f.id],
           ...f

--- a/src/components/BlueprintForm.vue
+++ b/src/components/BlueprintForm.vue
@@ -82,11 +82,36 @@ export default {
       })
     }
   },
+  methods: {
+    async fillFromLast () {
+      let results = await this.$store.state.db.find({
+        selector: {
+          form: this.config.id,
+        },
+        fields: ['date', 'form', 'data'],
+        sort: [{_id: 'desc'}],
+        limit: 1,
+      })
+      let last = results.docs[0]
+      if (last) {
+        this.fields.forEach(f => {
+          if (last.data[f.id] != undefined) {
+            this.$set(this.values, f.id, last.data[f.id])
+          }
+        })
+      }
+    }
+  },
   watch: {
     values: {
       deep: true,
       handler (v) {
         this.$emit('input', v)
+      }
+    },
+    'config.id': {
+      handler () {
+        this.values = {}
       }
     }
   }

--- a/src/components/Entry.vue
+++ b/src/components/Entry.vue
@@ -6,6 +6,12 @@
         :color="row.color"
         dot
       >
+        <structured-data
+          class="mb-4"
+          v-if="!isEmpty(row.entry.data)"
+          :data="row.entry.data"
+          :fields="$store.getters.fieldsById"
+        />
         <div
           class="rendered-markdown grey--text text--lighten-2"
           v-html="expand ? row.text : truncatedText"></div>
@@ -196,7 +202,10 @@
   </v-card>
 </template>
 <script>
+import isEmpty from 'lodash/isEmpty'
+
 import EntryForm from '@/components/EntryForm.vue'
+import StructuredData from '@/components/StructuredData.vue'
 import {getShortEntryId} from '@/utils'
 import truncate from 'truncate-html'
 truncate.setup({byWords: true, length: 60, keepWhitespaces: true })
@@ -206,10 +215,12 @@ export default {
     row: Object
   },
   components: {
-    EntryForm
+    EntryForm,
+    StructuredData
   },
   data () {
     return {
+      isEmpty,
       deleteDialog: false,
       deleteAllThread: false,
       isEditing: false,

--- a/src/components/EntryForm.vue
+++ b/src/components/EntryForm.vue
@@ -14,8 +14,6 @@
       </v-row>
       <form @submit.prevent="submit">
         <blueprint-form
-
-          v-if="$store.getters.formsById[currentFormId]"
           :key="blueprintFormKey"
           :config="$store.getters.formsById[currentFormId]"
           :available-fields="$store.getters.fieldsById"

--- a/src/components/EntryForm.vue
+++ b/src/components/EntryForm.vue
@@ -1,24 +1,7 @@
 <template>
   <v-card :color="color" outlined>
     <v-container class="narrow px-0">
-      <v-row v-if="formChoices.length > 1" class="d-flex justify-end">
-        <v-col
-          cols="12"
-          sm="4"
-        >
-          <v-select
-            v-model="currentFormId"
-            :items="formChoices"
-          ></v-select>
-        </v-col>
-      </v-row>
       <form @submit.prevent="submit">
-        <blueprint-form
-          :key="blueprintFormKey"
-          :config="$store.getters.formsById[currentFormId]"
-          :available-fields="$store.getters.fieldsById"
-          v-model="formData"
-        />
         <v-textarea
           clearable
           outlined
@@ -34,26 +17,36 @@
           v-model="text"
           hide-details
         ></v-textarea>
-        <v-row class="mt-1 mb-3 px-3">
-          <v-btn
-            v-for="shortcut in shortcuts" :key="shortcut.value"
-            :title="shortcut.name"
-            text
-            color="grey"
-            class="px-1"
-            style="min-width: 2.5em"
-            @click.prevent="insertAtCursor($refs.textarea.$el.querySelector('textarea'), shortcut.value)"
+        <v-row class="d-flex justify-space-between align-center">
+          <v-col
+            cols="12"
+            sm="8"
+            class="pb-0"
           >
-            
-            {{ shortcut.value }}
-          </v-btn>
-        </v-row>
-        <div class="d-flex align-top justify-space-between">
-          <div>
+            <v-row class="mt-1 mb-3 px-3">
+              <v-btn
+                v-for="shortcut in shortcuts" :key="shortcut.value"
+                :title="shortcut.name"
+                text
+                color="grey"
+                class="px-1"
+                style="min-width: 2.5em"
+                @click.prevent="insertAtCursor($refs.textarea.$el.querySelector('textarea'), shortcut.value)"
+              >
+                
+                {{ shortcut.value }}
+              </v-btn>
+            </v-row>
+          </v-col>
+          <v-col
+            cols="12"
+            sm="4"
+            class="py-0"
+          >
             <v-switch
               v-model="showDateField"
               label="Set date..."
-              class="mt-1"
+              class="mb-0"
             ></v-switch>
             <template v-if="showDateField">
               <v-text-field
@@ -69,8 +62,51 @@
                 Set to now
               </v-btn>
             </template>
-          </div>
-          <div>
+          </v-col>
+        </v-row>
+        <v-row
+          class="mt-0 d-flex justify-space-between align-center">
+          <v-col
+            v-if="formChoices.length > 1"
+            cols="12"
+            sm="4"
+          >
+            <v-select
+              label="Type"
+              v-model="currentFormId"
+              :items="formChoices"
+            ></v-select>
+          </v-col>
+          <v-col
+            v-if="currentFormId"
+            cols="12"
+            sm="4"
+          >
+            <v-btn
+              small
+              @click="$refs.blueprintForm.fillFromLast()"
+            >
+              Reuse last values
+            </v-btn>
+          </v-col>
+          <v-col
+            v-if="!isEmpty(formData) || currentFormId"
+            cols="12"
+            sm="12"
+          >
+            <blueprint-form
+              ref="blueprintForm"
+              :key="blueprintFormKey"
+              :config="$store.getters.formsById[currentFormId]"
+              :available-fields="$store.getters.fieldsById"
+              v-model="formData"
+            />
+          </v-col>
+          <v-col
+            cols="12"
+            :sm="(!isEmpty(formData) || currentFormId || formChoices.length < 2) ? 12 : 6"
+            class="text-right"
+          >
             <v-btn
               v-if="entry || thread" 
               text
@@ -80,8 +116,9 @@
               Cancel
             </v-btn>
             <v-btn :color="$theme.mainButton.color" type="submit">Save</v-btn>
-          </div>
-        </div>   
+          </v-col>
+
+        </v-row>
       </form>   
     </v-container>
   </v-card>
@@ -127,6 +164,7 @@ export default {
       textDate: null,
       maxDate: null,
       showDateField: false,
+      isEmpty,
     }
   },
   async created () {

--- a/src/components/StructuredData.vue
+++ b/src/components/StructuredData.vue
@@ -1,0 +1,38 @@
+<template>
+  <v-simple-table>
+    <template v-slot:default>
+      <tbody>
+        <tr v-for="row in rows" :key="row.id">
+          <td>
+            {{ row.label }}
+          </td>
+          <td>
+            {{ row.value }}
+          </td>
+        </tr>
+      </tbody>
+    </template>
+  </v-simple-table>
+</template>
+<script>
+export default {
+  props: ['data', 'fields'],
+  computed: {
+    rows () {
+      let r = []
+      for (const key in this.data) {
+        if (Object.hasOwnProperty.call(this.data, key)) {
+          const value = this.data[key];
+          let field = this.fields[key] || {}
+          r.push({
+            id: key,
+            label: field.label || key,
+            value: value
+          })
+        }
+      }
+      return r
+    }
+  }
+}
+</script>

--- a/src/store.js
+++ b/src/store.js
@@ -89,6 +89,9 @@ const store = new Vuex.Store({
       state.db.createIndex({
         index: {fields: ['date', 'type', 'thread']}
       })
+      state.db.createIndex({
+        index: {fields: ['form', 'date']}
+      })
     },
     serviceWorker: (state, value) => {
       state.serviceWorker = {...state.serviceWorker, ...value}

--- a/src/store.js
+++ b/src/store.js
@@ -139,9 +139,14 @@ const store = new Vuex.Store({
       choices.push({value: index, text: 'Done'})
       return choices
     },
-    forms: (state) => {
+    enabledBlueprints: (state) => {
+      return state.loadedBlueprints.filter(b => {
+        return state.settings.blueprints.indexOf(b.id) > -1
+      })
+    },
+    forms: (state, getters) => {
       let allForms = []
-      state.loadedBlueprints.forEach(l => {
+      getters.enabledBlueprints.forEach(l => {
         allForms = [...allForms, ...(l.forms || [])]
       })
       return allForms
@@ -153,9 +158,9 @@ const store = new Vuex.Store({
       })
       return forms
     },
-    fields: (state) => {
+    fields: (state, getters) => {
       let allFields = []
-      state.loadedBlueprints.forEach(l => {
+      getters.enabledBlueprints.forEach(l => {
         allFields = [...allFields, ...(l.fields || [])]
       })
       return allFields
@@ -400,17 +405,11 @@ const store = new Vuex.Store({
       }
       commit("settings", s)
     },
-    async loadBlueprints ({commit}, configs) {
+    async loadBlueprints ({commit}) {
       let builtins = await getBuiltinBlueprints()
-      let b = []
-      for (const config of configs) {
-        if (builtins[config.id]) {
-          b.push(builtins[config.id])
-        } else { 
-          console.warn("Unknown blueprint", config)
-        }
-      }
-      commit("loadedBlueprints", b)
+      let allBlueprints = {...builtins}
+
+      commit("loadedBlueprints", Object.keys(allBlueprints).map(b => {return allBlueprints[b]}))
     },
   },
   modules: {

--- a/src/store.js
+++ b/src/store.js
@@ -14,7 +14,7 @@ async function getBuiltinBlueprints () {
   return {
     "builtin:mood": (await import("@/blueprints/builtin:mood.json")).default,
     "builtin:tags": (await import("@/blueprints/builtin:tags.json")).default,
-    // "builtin:travel": (await import("@/blueprints/builtin:travel.json")).default,
+    "builtin:travel": (await import("@/blueprints/builtin:travel.json")).default,
   }
 }
 
@@ -138,7 +138,35 @@ const store = new Vuex.Store({
       })
       choices.push({value: index, text: 'Done'})
       return choices
-    }
+    },
+    forms: (state) => {
+      let allForms = []
+      state.loadedBlueprints.forEach(l => {
+        allForms = [...allForms, ...(l.forms || [])]
+      })
+      return allForms
+    },
+    formsById: (state, getters) => {
+      let forms = {}
+      getters.forms.forEach(f => {
+        forms[f.id] = f
+      })
+      return forms
+    },
+    fields: (state) => {
+      let allFields = []
+      state.loadedBlueprints.forEach(l => {
+        allFields = [...allFields, ...(l.fields || [])]
+      })
+      return allFields
+    },
+    fieldsById: (state, getters) => {
+      let fields = {}
+      getters.fields.forEach(f => {
+        fields[f.id] = f
+      })
+      return fields
+    },
   },
   actions: {
     async addEntry ({state, dispatch}, entryData) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -69,6 +69,7 @@ export function getNewEntryData(text, additionalValues = {}) {
     favorite: false,
     thread: additionalValues.thread || null,
     replies: additionalValues.replies || [],
+    form: null,
   }
   let annotations = []
   entryData.tags.forEach(t => {
@@ -232,6 +233,7 @@ export function getCompleteEntry (e) {
     favorite: e.favorite || false,
     thread: e.thread || null,
     replies: e.replies || [],
+    form: e.form,
   }
   e.tags.forEach((t) => {
     entry.tags[t.id] = {

--- a/src/utils.js
+++ b/src/utils.js
@@ -460,10 +460,9 @@ export const SETTINGS = [
   }}},
   {name: "blueprints", default: () => {
     return [
-      {id: "builtin:mood"},
-      {id: "builtin:tags"},
-      {id: "builtin:travel"},
-      ]
+      "builtin:mood",
+      "builtin:tags",
+    ]
   }},
 ]
 

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -6,6 +6,34 @@
 
     <v-card
       tag="form"
+      id="blueprints"
+      class="section mb-8"
+      :color="$theme.card.color"
+      @submit.prevent="$store.dispatch('setSetting', {name: 'blueprints', value: enabledBlueprints})"
+    >
+      <v-card-title class="headline">Blueprints</v-card-title>
+
+      <v-card-text :class="$theme.card.textSize">
+        <p>
+          Blueprints provide additional features in Tempo such as vizualisations or forms.
+          Some blueprints are enabled by default.
+        </p>
+        <v-checkbox
+          v-model="enabledBlueprints"
+          :label="`${blueprint.label} · ${blueprint.title}`"
+          :value="blueprint.id"
+          v-for="blueprint in $store.state.loadedBlueprints"
+          :key="blueprint.id"
+          hide-details
+        ></v-checkbox>
+      </v-card-text>
+      <v-card-actions>
+        <v-btn color="primary" type="submit">Save</v-btn>
+      </v-card-actions>
+    </v-card>
+
+    <v-card
+      tag="form"
       id="aliases"
       class="section mb-8"
       :color="$theme.card.color"
@@ -294,6 +322,7 @@ export default {
         board: true,
         settings: true,
       },
+      enabledBlueprints: [...this.$store.state.settings.blueprints || []],
       importLogs: [],
       syncStatus: null,
       toImportFile: null,

--- a/src/views/Vizualisation.vue
+++ b/src/views/Vizualisation.vue
@@ -143,7 +143,7 @@ export default {
     }
   },
   async created () {
-    await this.$store.dispatch("loadBlueprints", this.$store.state.settings.blueprints)
+    await this.$store.dispatch("loadBlueprints")
   },
   computed: {
     entries () {
@@ -156,11 +156,11 @@ export default {
       return getQueryableTags(this.queryableEntries)
     },
     selectedBlueprint () {
-      return this.$store.state.loadedBlueprints[this.params.selectedBlueprintIdx]
+      return this.$store.getters.enabledBlueprints[this.params.selectedBlueprintIdx]
     },
     blueprintChoices () {
       let i = -1
-      return this.$store.state.loadedBlueprints.map(b => {
+      return this.$store.getters.enabledBlueprints.map(b => {
         i += 1
         return {
           text: b.label,

--- a/src/views/Vizualisation.vue
+++ b/src/views/Vizualisation.vue
@@ -32,9 +32,9 @@
                   <v-text-field
                     v-model="params.start"
                     label="Start"
-                    readonly
                     v-bind="attrs"
                     v-on="on"
+                    clearable
                   ></v-text-field>
                 </template>
                 <v-date-picker
@@ -61,9 +61,9 @@
                   <v-text-field
                     v-model="params.end"
                     label="End"
-                    readonly
                     v-bind="attrs"
                     v-on="on"
+                    clearable
                   ></v-text-field>
                 </template>
                 <v-date-picker
@@ -172,6 +172,12 @@ export default {
   watch: {
     params: {
       handler (v) {
+        if (!v.start) {
+          v.start = this.entries[0].date.slice(0, 10)
+        }
+        if (!v.end) {
+          v.end = this.entries[this.entries.length - 1].date.slice(0, 10)
+        }
         let query = {
           blueprint: v.selectedBlueprintIdx,
           q: '',

--- a/tests/unit/utils.spec.js
+++ b/tests/unit/utils.spec.js
@@ -39,6 +39,7 @@ describe('utils', () => {
       favorite: false,
       replies: [],
       thread: null,
+      form: null,
     }
     expect(getNewEntryData(msg)).to.deep.equal(expected)
   })
@@ -53,6 +54,7 @@ describe('utils', () => {
       favorite: false,
       replies: ['bar'],
       thread: 'foo',
+      form: null,
     };
     expect(getNewEntryData(msg, {thread: 'foo', replies: ['bar']})).to.deep.equal(expected);
   });
@@ -72,6 +74,7 @@ describe('utils', () => {
       favorite: false,
       replies: [],
       thread: null,
+      form: null,
     }
     expect(getNewEntryData(msg)).to.deep.equal(expected)
   })
@@ -276,7 +279,8 @@ describe('utils', () => {
         'work:duration': "8.5"
       },
       thread: 'foo',
-      replies: ['bar']
+      replies: ['bar'],
+      form: 'foo:form',
     }
     const expected = {
       ...entry,
@@ -319,7 +323,8 @@ describe('utils', () => {
       },
       favorite: false,
       thread: 'foo',
-      replies: ['bar']
+      replies: ['bar'],
+      form: 'foo:form',
     }
     expected.week = `${expected.year}-${expected.weeknumber}`
     const result = getCompleteEntry(entry)


### PR DESCRIPTION
- [x] Basic JSON specification for forms in blueprints
- [x] Use forms declared on blueprints to enrich the entry form and store additional data (to replace the `@foo:bar` annotation format)
- [x] Dedicated UI in settings to list available blueprints and enable/disable them
- [x] Show structured data in entries
- [x] Prefill forms from previous entries for faster input

# Demo

https://user-images.githubusercontent.com/1970915/189187325-5af99074-aa4f-41d0-a658-c739594f7127.mp4

