### PR TITLE
Trigger couchdb sync on tasks creation/update/deletion

### DIFF
--- a/src/components/TaskCard.vue
+++ b/src/components/TaskCard.vue
@@ -146,15 +146,17 @@ export default {
     }
   },
   methods: {
-    deleteTask () {
+    async deleteTask () {
       this.$store.state.db.remove(this.task)
       this.$emit('deleted', this.task)
+      await this.$store.dispatch('forceSync', {updateLastSync: false})
     },
     async updateTask () {
       let result = await this.$store.state.db.put(this.newTask)
       this.newTask._rev = result.rev
       this.expanded = false
       this.$emit('updated', this.newTask)
+      await this.$store.dispatch('forceSync', {updateLastSync: false})
     },
   },
   watch: {

--- a/src/views/Tasks.vue
+++ b/src/views/Tasks.vue
@@ -242,6 +242,7 @@ export default {
       this.newTaskText = null
       this.newTaskCategory = null
       trackEvent(this.$store, "task.created")
+      await this.$store.dispatch('forceSync', {updateLastSync: false})
     },
     async updateTasks () {
       this.tasks = await getTasks(this.$store, this.query)
@@ -268,6 +269,7 @@ export default {
           t._rev = result.rev
         }
       })
+      await this.$store.dispatch('forceSync', {updateLastSync: false})
     },
     async removeTasks(tasks) {
       let toDelete = tasks.map(t => {


### PR DESCRIPTION
We had that for years on diary entries, creation/modification/deletion would be broadcasted immediatly on couchdb. Somehow I forgot it on tasks, let's fix it.