### PR TITLE
Added grouping control for visualizations

### DIFF
--- a/src/blueprints/builtin:mood.json
+++ b/src/blueprints/builtin:mood.json
@@ -5,18 +5,18 @@
   "version": "1",
   "visualizations": [
     {
-      "label": "Mood by day",
+      "label": "Mood by period: {{ groupByPeriodLabel }}",
       "help": "Higher is better",
-      "query": "SELECT date, sum(CASE WHEN mood > 0 THEN mood ELSE 0 END) as Positive, sum(CASE WHEN mood < 0 THEN mood ELSE 0 END) as Negative FROM ? GROUP BY date ORDER BY date DESC",
+      "query": "SELECT {{ groupByPeriod }}, sum(CASE WHEN mood > 0 THEN mood ELSE 0 END) as Positive, sum(CASE WHEN mood < 0 THEN mood ELSE 0 END) as Negative FROM ? GROUP BY {{ groupByPeriod }} ORDER BY {{ groupByPeriod }} DESC",
       "displayType": "bar",
       "displayOptions": {
         "colors": ["green", "orange"]
       }
     },
     {
-      "label": "Mood instability",
+      "label": "Mood instability by period: {{ groupByPeriodLabel }}",
       "help": "Lower is stabler",
-      "query": "Select date, posmood * negmood / 10 as instability From (SELECT date, sum(CASE when mood>0 then mood else 0 END) as posmood,  sum(CASE when mood<0 then abs(mood) else 0 END) AS negmood FROM ? GROUP BY date ORDER BY date DESC)",
+      "query": "Select {{ groupByPeriod }}, (min(posmood, abs(negmood)) / max(max(posmood, abs(negmood)), 1)) as instability From (SELECT {{ groupByPeriod }}, sum(CASE when mood>0 then mood else 0 END) as posmood,  sum(CASE when mood<0 then mood else 0 END) AS negmood FROM ? GROUP BY {{ groupByPeriod }} ORDER BY {{ groupByPeriod }} DESC)",
       "displayType": "bar",
       "displayOptions": {
         "colors": ["purple"]

--- a/src/components/Dataviz.vue
+++ b/src/components/Dataviz.vue
@@ -6,6 +6,7 @@
       :config="visualization"
       :tags="tags"
       :builtin="true"
+      :group-by-period="params.groupByPeriod"
       :entries="entries">
     </blueprint-visualization>
   </div>
@@ -13,7 +14,7 @@
 <script>
 
 export default {
-  props: ['entries', 'tags', 'blueprint'],
+  props: ['entries', 'tags', 'blueprint', 'params'],
   components: {
     BlueprintVisualization:  () => import(/* webpackChunkName: "visualization" */ "@/components/BlueprintVisualization"),
   },

--- a/src/components/VisualizationConfig.vue
+++ b/src/components/VisualizationConfig.vue
@@ -1,18 +1,15 @@
 <template>
   <v-card tag="section" class="mb-8" :color="$theme.card.color">
-    <v-card-title class="headline">Options</v-card-title>
+    <v-card-title class="headline">
+      
+      <v-select
+        v-model="params.selectedBlueprintId"
+        :items="blueprintChoices"
+        label="Visualization"
+      ></v-select>
+    </v-card-title>
     <v-card-text :class="$theme.card.textSize">
       <v-row>
-        <v-col
-          cols="4"
-          v-if="showBlueprintSelector"
-        >
-          <v-select
-            v-model="params.selectedBlueprintId"
-            :items="blueprintChoices"
-            label="Name"
-          ></v-select>
-        </v-col>
         <v-col
           cols="4"
         >
@@ -70,6 +67,16 @@
             ></v-date-picker>
           </v-menu>
         </v-col>
+        <v-col
+          cols="4"
+          v-if="showGroupByPeriodControl"
+        >
+          <v-select
+            v-model="params.groupByPeriod"
+            :items="groupByPeriodOptions"
+            label="Group by period"
+          ></v-select>
+        </v-col>
       </v-row>
       <search-form
         :value="$store.state.searchQuery"
@@ -83,11 +90,12 @@
 <script>
 import isEqual from 'lodash/isEqual'
 import SearchForm from '@/components/SearchForm.vue'
-
+import {groupByPeriodOptions} from '@/utils'
 export default {
   props: {
     value: {},
     allEntries: {},
+    selectedBlueprint: {},
     showBlueprintSelector: {default: true},
   },
   components: {
@@ -99,7 +107,8 @@ export default {
       showEndMenu: false,
       params: {
         ...this.value
-      }
+      },
+      groupByPeriodOptions
     }
   },
   computed: {
@@ -112,7 +121,20 @@ export default {
           value: b.id,
         }
       })
-    }
+    },
+    showGroupByPeriodControl () {
+      if (!this.selectedBlueprint) {
+        return false
+      }
+      let visualizations = this.selectedBlueprint.visualizations || []
+      for (let index = 0; index < visualizations.length; index++) {
+        const v = visualizations[index];
+        if (v.query.includes('{{ groupByPeriod }}')) {
+          return true
+        }
+      }
+      return false
+    } 
   },
   watch: {
     params: {

--- a/src/router.js
+++ b/src/router.js
@@ -27,6 +27,7 @@ const routes = [
           blueprint: route.query.blueprint,
           defaultEnd: route.query.end || null,
           defaultStart: route.query.start || null,
+          defaultGroupByPeriod: route.query.period || 'date',
         }),
       },
       {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,22 @@
 import Vue from 'vue'
 import sub from 'date-fns/sub'
 
+export const groupByPeriodOptions = [
+  {text: 'Date', value: 'date'},
+  {text: 'Year - Week', value: 'yearWeek'},
+  {text: 'Year - Month', value: 'yearMonth'},
+  {text: 'Month', value: 'month'},
+  {text: 'Day of month', value: 'day'},
+  {text: 'Day of week', value: 'weekDay'},
+  {text: 'Week', value: 'weekNumber'},
+  {text: 'Year', value: 'year'},
+]
+export const groupByPeriodOptionsByValue = {}
+
+groupByPeriodOptions.forEach(v => {
+  groupByPeriodOptionsByValue[v.value] = v.text
+})
+
 const signToMood = {
   '+': 1,
   '-': -1,
@@ -250,6 +266,7 @@ export function getCompleteEntry (e) {
   let fullDate = new Date(e.date)
   let weekNumber = getWeekNumber(fullDate)
   let year = fullDate.getFullYear()
+  let month = fullDate.getMonth() + 1
   let entry = {
     text: e.text,
     _id: e._id,
@@ -258,11 +275,13 @@ export function getCompleteEntry (e) {
     fullDate: fullDate,
     date: fullDate.toISOString().split('T')[0],
     year: year,
-    month: fullDate.getMonth() + 1,
+    month,
+    monthNumber: month,
+    yearMonth: `${year}-${String(month).padStart(2, '0')}`,
     day: fullDate.getDate(),
-    weekday: fullDate.getDay() + 1,
-    weeknumber: weekNumber,
-    week: `${year}-${weekNumber}`,
+    weekDay: fullDate.getDay() + 1,
+    weekNumber: weekNumber,
+    yearWeek: `${year}-${String(weekNumber).padStart(2, '0')}`,
     tags: {},
     data: e.data || null,
     favorite: e.favorite || false,

--- a/src/views/Visualization.vue
+++ b/src/views/Visualization.vue
@@ -4,6 +4,7 @@
       <visualization-config
         v-model="params"
         :all-entries="allEntries"
+        :selected-blueprint="selectedBlueprint" 
       ></visualization-config>
     </v-container>
     <v-container class="mt-4 py-0 px-0" v-if="selectedBlueprint">
@@ -11,6 +12,7 @@
         :blueprint="selectedBlueprint"      
         :entries="queryableEntries"
         :tags="queryableTags"
+        :params="params"
       ></dataviz>
     </v-container>
   </div>
@@ -25,6 +27,7 @@ export default {
     blueprint: {type: String, default: null},
     defaultStart: {type: String, default: null},
     defaultEnd: {type: String, default: null},
+    defaultGroupByPeriod: {type: String, default: 'date'},
   },
   components: {
     Dataviz:  () => import(/* webpackChunkName: "visualization" */ "@/components/Dataviz"),
@@ -35,6 +38,7 @@ export default {
       params: {
         ...getDates(this.defaultStart, this.defaultEnd),
         selectedBlueprintId: this.blueprint,
+        groupByPeriod: this.defaultGroupByPeriod,
       },
     }
   },
@@ -72,6 +76,7 @@ export default {
           q: '',
           start: v.start,
           end: v.end,
+          period: v.groupByPeriod || 'date'
         }
         this.$router.push({ path: this.$route.path, query })
       },

--- a/tests/unit/utils.spec.js
+++ b/tests/unit/utils.spec.js
@@ -371,10 +371,13 @@ describe('utils', () => {
       fullDate: date,
       date: date.toISOString().split('T')[0],
       year: date.getFullYear(),
-      month: date.getMonth() + 1,
+      month : date.getMonth() + 1,
+      monthNumber: date.getMonth() + 1,
       day: date.getDate(),
-      weekday: date.getDay() + 1,
-      weeknumber: getWeekNumber(date),
+      weekDay: date.getDay() + 1,
+      weekNumber: getWeekNumber(date),
+      yearWeek: `${date.getFullYear()}-${String(getWeekNumber(date)).padStart(2, '0')}`,
+      yearMonth: `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`,
       tags: {
         "happy": {
           id: "happy",
@@ -407,7 +410,6 @@ describe('utils', () => {
       replies: ['bar'],
       form: 'foo:form',
     }
-    expected.week = `${expected.year}-${expected.weeknumber}`
     const result = getCompleteEntry(entry)
     expect(result).to.deep.equal(expected)
   })


### PR DESCRIPTION
- [x] Support for using other time grouping in visualizations. The default and only « date » grouping was difficult to work with on large datasets
- [x] Fix mood instability formula. Edge cases are now handled properly, and the value will always be between 0 and 1

# Demo

https://user-images.githubusercontent.com/1970915/211390443-d9948434-a611-4458-ac3c-504b43213f96.mp4

