### PR TITLE
Fix #51: POST entry content in webhook

### DIFF
--- a/src/components/Entry.vue
+++ b/src/components/Entry.vue
@@ -291,7 +291,11 @@ export default {
       await this.$store.state.db.remove(this.row.rawEntry)
       await this.$store.dispatch('rebuildThread', threadId)
       await this.$store.dispatch('forceSync', {updateLastSync: false})
-      await this.$store.dispatch('triggerWebhook')
+      let webhookPayload = {
+        event: 'entry.deleted',
+        entry: this.row.rawEntry,
+      }
+      await this.$store.dispatch('triggerWebhook', {payload: webhookPayload})
     },
   }
 }

--- a/src/components/EntryForm.vue
+++ b/src/components/EntryForm.vue
@@ -213,7 +213,11 @@ export default {
         e = await this.addNew()
       }
       this.$emit('submitted', e)
-      await this.$store.dispatch('triggerWebhook')
+      let webhookPayload = {
+        event: this.entry ? 'entry.updated' : 'entry.created',
+        entry: e,
+      }
+      await this.$store.dispatch('triggerWebhook', {payload: webhookPayload})
     },
     async addNew () {
       let date = this.date ? new Date(this.date) : new Date()

--- a/src/store.js
+++ b/src/store.js
@@ -341,7 +341,7 @@ const store = new Vuex.Store({
     async setWebhook ({dispatch}, {url}) {
       await dispatch("setSetting", {name: "webhook", value: {url}})
     },
-    async triggerWebhook ({state}, url) {
+    async triggerWebhook ({state}, {url, payload}) {
       url = url || state.settings.webhook.url
       if (!url) {
         console.log("No webhook configured, skipping", state.settings.webhook.url)
@@ -350,7 +350,10 @@ const store = new Vuex.Store({
       console.log("Sending webhook to", url)
       return await fetch(url, {
         method: "POST",
-        body: ""
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(payload || {})
       })
     },
     async addChart ({state, dispatch}, config) {

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -292,6 +292,7 @@
 import AliasForm from '@/components/AliasForm'
 
 import {
+  getNewEntryData,
   search,
   getBlueprints,
   getTasks,
@@ -462,7 +463,11 @@ export default {
     },
     async triggerWebhook (url) {
       await this.$store.dispatch("forceSync", {updateLastSync: true})
-      await this.$store.dispatch('triggerWebhook', url)
+      let payload = {
+        event: 'entry.created',
+        entry: getNewEntryData('Hello there, this is a #test')
+      }
+      await this.$store.dispatch('triggerWebhook', {url, payload})
     },
     async importData () {
       this.importLogs = []


### PR DESCRIPTION
Instead of an empty body, we now post an event type and the associated entry. A typical webhook payload looks like this:

```json
{
    "event": "entry.created",
    "entry": {
        "text": "Test",
        "tags": [],
        "mood": 0,
        "type": "entry",
        "data": null,
        "favorite": false,
        "thread": null,
        "replies": [],
        "form": null,
        "date": "2023-02-16T14:18:40.669Z",
        "_id": "2023-02-16T14:18:40.669Z",
        "_rev": "1-3d6a4c5e599d4817d0db25231d01fc8a"
    }
}
```

Event can be one of `entry.created`, `entry.updated` or `entry.deleted`. The `entry` key will contain the data of the corresponding entry. The structure of the `entry` data should remain stable but is currently a dump of the internal object used by Tempo and might be subject to change over time.  Once I'm confident webhooks work as expected, I will freeze the changes so that webhooks handler don't break.

# A note about CORS

Note that since the webhook is sent from a web browser, the browser will likely issue a [preflight CORS request](https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request) before the actual POST request is sent. Your webhook handler will need to answer this request with the appropriate headers, typically:

```
Access-Control-Allow-Origin: https://yourtemposerver
Access-Control-Allow-Methods: POST, OPTIONS
Access-Control-Allow-Headers: content-type
```

Otherwise, the webhook won't be sent.