### PR TITLE
Fix #58: support for autosuggest on blueprint fields

### DIFF
--- a/src/components/BlueprintForm.vue
+++ b/src/components/BlueprintForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="fields.length > 0">
+  <div v-if="fields.length > 0" :key="formConfig.id">
     <p v-if="formConfig.help">{{ formConfig.help }}</p>
     <v-row>
       <v-col
@@ -8,7 +8,7 @@
         cols="12"
         sm="6"
       >
-        <blueprint-field v-model="values[field.id]" :field="field" />
+        <blueprint-field v-model="values[field.id]" :field="field" :form-id="formConfig.id" />
       </v-col>
     </v-row>
   </div>

--- a/src/schemas/blueprint.json
+++ b/src/schemas/blueprint.json
@@ -118,6 +118,12 @@
             "examples": [
               ["Paracetamol", "D Vitamin", "B12 Vitamin"]
             ]
+          },
+          "autosuggest": {
+            "type": "string",
+            "enum": ["form", "field", null],
+            "description": "If not null, will also include already inputed values in suggestions. If 'form' is used, then only values for matching form are included. If 'field' is used, all values are included, regardless of the form",
+            "default": null
           }
         }
       }

--- a/src/views/BlueprintEditor.vue
+++ b/src/views/BlueprintEditor.vue
@@ -306,6 +306,8 @@ fields:
       - Home
       - Lola
       - Doctor
+    # If a new value, not in suggestions is inputed, it will show up in suggestions
+    autosuggest: "form"
   # The second one is a boolean (yes/no) field
   # that defaults to true
   - id: onDiet


### PR DESCRIPTION
This implement a new autosuggestion mechanism so that you can see, for a given blueprint field, already used values in a combobox. Simply add `autosuggest: form` or `autosuggest: field` to the field definition. 

If `autosuggest: field` is used, suggestions will be populated from any use of the field, regardless of the form. If `autosuggest: form` is used, suggestions will rely on the current form, to reduce noise.

https://user-images.githubusercontent.com/1970915/229347600-42659a0c-9061-4fd3-99a1-85fb13e1539f.mp4

cc @entropyqueen 
