### PR TITLE
Persist CouchDB configuration in `.env`-file 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ COPY package.json ./
 COPY yarn.lock ./
 RUN yarn install
 COPY . ./
+COPY .env ./.env
 RUN yarn build
 
 # production environment

--- a/README.md
+++ b/README.md
@@ -335,6 +335,14 @@ Then:
 - Create a user and a database
 - Setup sync in Tempo's web UI
 
+To persist the CouchDB configuration for your instance, you can define a `.env`-file with the following content (credentials as defined above):
+
+```
+VUE_APP_CDB_URL=https://<CouchDB_URL>/<DB_Name>
+VUE_APP_CDB_USER=admin
+VUE_APP_CDB_PASS=password
+```
+
 ### Deploying using Docker
 
 If you want to deploy Tempo using Docker, you can use our Dockerfile:

--- a/src/main.js
+++ b/src/main.js
@@ -84,6 +84,15 @@ Vue.prototype.$icons = {
   mdiTrashCan,
 }
 
+function abOrDefault (a, b, def) {
+  if (a)
+    return a;
+  else if (b)
+    return b;
+  else
+    return def;
+}
+
 Vue.prototype.$theme = {
   appBar: {
     color: "pink darken-4",
@@ -137,9 +146,9 @@ new Vue({
     this.$store.dispatch(
       'setupSync',
       {
-        url: this.$store.state.couchDbUrl,
-        username: this.$store.state.couchDbUsername,
-        password: this.$store.state.couchDbPassword,
+        url: abOrDefault(this.$store.state.couchDbUrl, process.env.VUE_APP_CDB_URL, null),
+        username: abOrDefault(this.$store.state.couchDbUsername, process.env.VUE_APP_CDB_USER, null),
+        password: abOrDefault(this.$store.state.couchDbPassword, process.env.VUE_APP_CDB_PASS, null),
       }
       )
   }


### PR DESCRIPTION
Hi,

I got bothered by entering the credentials on each device.
Thus, I persisted it in a `.env`-file.

Best regards
Duda